### PR TITLE
Add rough draft of V2 API specs, based on current tests

### DIFF
--- a/docs/specs/html2wt.yaml
+++ b/docs/specs/html2wt.yaml
@@ -1,0 +1,87 @@
+swagger: '2.0'
+info:
+  title: Parsoid conversion API
+  version: '2.0.0'
+basePath: /v2
+paths:
+  /{domain}/wt/:
+    parameters:
+      - name: domain
+        in: path
+        type: string
+        required: true
+        default: en.wikipedia.org
+    post:
+      produces:
+        - application/json; profile=mediawiki.org/specs/data-parsoid/0.0.1
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/Source'
+      responses:
+        200:
+          description: Wikitext
+          schema:
+            $ref: '#/definitions/Wikitext'
+        400:
+          description: Invalid source
+definitions:
+  Source:
+    title: Source
+  Html:
+    extends: Source
+    properties:
+      html:
+        type: string
+  HtmlBundle:
+    extends: Source
+    properties:
+      html:
+        schema:
+          $ref: '#/definitions/PlainRequest'
+      data-parsoid:
+        schema:
+          $ref: '#/definitions/DataParsoidRequest'
+      original:
+        schema:
+          $ref: '#/definitions/Original'
+  DataParsoidRequest:
+    properties:
+      headers:
+        type: object
+      body:
+        schema:
+          $ref: '#/definitions/DataParsoid'
+  DataParsoid:
+    properties:
+      counter:
+        type: integer
+      ids:
+        type: object
+  PlainRequest:
+    properties:
+      headers:
+        type: object
+      body:
+        type: string
+  Original:
+    properties:
+      revid:
+        type: integer
+      title:
+        type: string
+      wikitext:
+        schema:
+          $ref: '#/definitions/PlainRequest'
+      html:
+        schema:
+          $ref: '#/definitions/PlainRequest'
+      data-parsoid:
+        schema:
+          $ref: '#/definitions/DataParsoidRequest'
+  Wikitext:
+    properties:
+      wikitext:
+        type: string

--- a/docs/specs/wt2html.yaml
+++ b/docs/specs/wt2html.yaml
@@ -1,0 +1,150 @@
+swagger: '2.0'
+info:
+  title: Parsoid conversion API
+  version: '2.0.0'
+basePath: /v2
+paths:
+  /{domain}/html/:
+    parameters:
+      - name: domain
+        in: path
+        type: string
+        required: true
+        default: en.wikipedia.org
+    post:
+      produces:
+        - text/html; profile=mediawiki.org/specs/html/1.0.0
+      parameters:
+        - in: body
+          name: body
+          schema:
+            $ref: '#/definitions/Orphan'
+      responses:
+        200:
+          description: HTML
+        400:
+          description: Invalid input
+  /{domain}/html/{title}:
+    parameters:
+      - name: domain
+        in: path
+        type: string
+        required: true
+        default: en.wikipedia.org
+      - name: title
+        in: path
+        type: string
+        required: true
+        default: Main_Page
+    get:
+      responses:
+        302:
+          description: Redirect
+  /{domain}/html/{title}/{revision}:
+    parameters:
+      - name: domain
+        in: path
+        type: string
+        required: true
+        default: en.wikipedia.org
+      - name: title
+        in: path
+        type: string
+        required: true
+        default: Main_Page
+      - name: revision
+        in: path
+        type: string
+        required: true
+        default: 1
+    get:
+      produces:
+        - text/html; profile=mediawiki.org/specs/html/1.0.0
+      responses:
+        200:
+          description: HTML
+    post:
+      summary: Convert a revision to html 
+      produces:
+        - text/html; profile=mediawiki.org/specs/html/1.0.0
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/Page'
+      responses:
+        200:
+          description: HTML
+definitions:
+  Orphan:
+    title: Raw source
+  WikitextRaw:
+    extends: Orphan
+    properties:
+      wikitext:
+        type: string
+  WikitextRequest:
+    extends: Orphan
+    properties:
+      wikitext:
+        schema:
+          $ref: '#/definitions/PlainRequest'
+  PlainRequest:
+    properties:
+      headers:
+        type: object
+      body:
+        type: string
+  DataParsoidRequest:
+    properties:
+      headers:
+        type: object
+      body:
+        schema:
+          $ref: '#/definitions/DataParsoid'
+  DataParsoid:
+    properties:
+      counter:
+        type: integer
+      ids:
+        type: object
+  Page:
+    title: Page
+  Previous:
+    extends: Page
+    properties:
+      revid:
+        type: integer
+      html:
+        schema:
+          $ref: '#/definitions/PlainRequest'
+      data-parsoid:
+        schema:
+          $ref: '#/definitions/DataParsoidRequest'
+  Original:
+    extends: Page
+    properties:
+      update:
+        schema:
+          $ref: '#/definitions/Update'
+      original:
+        schema:
+          $ref: '#/definitions/Original'
+  Update:
+    properties:
+      templates:
+        type: boolean
+  Original:
+    properties:
+      revid:
+        type: integer
+      html:
+        schema:
+          $ref: '#/definitions/PlainRequest'
+      data-parsoid:
+        schema:
+          $ref: '#/definitions/DataParsoidRequest'
+      wikitext:
+        schema:
+          $ref: '#/definitions/WikitextRequest'

--- a/docs/specs/wt2pagebundle.yaml
+++ b/docs/specs/wt2pagebundle.yaml
@@ -1,0 +1,38 @@
+swagger: '2.0'
+info:
+  title: Parsoid conversion API
+  version: '2.0.0'
+basePath: /v2
+paths:
+  /{domain}/html/{title}/{revision}:
+    parameters:
+      - name: domain
+        in: path
+        type: string
+        required: true
+        default: en.wikipedia.org
+      - name: title
+        in: path
+        type: string
+        required: true
+        default: Main_Page
+      - name: revision
+        in: path
+        type: string
+        required: true
+        default: 1
+    get:
+      produces:
+        - application/json; profile=mediawiki.org/specs/data-parsoid/0.0.1
+      responses:
+        200:
+          description: Page bundle
+          schema:
+            $ref: '#/definitions/PageBundle'
+definitions:
+  PageBundle:
+    parameters:
+      html:
+        type: object
+      data-parsoid:
+        type: object


### PR DESCRIPTION
These are pretty rough, since they're based solely on [the current tests](https://github.com/wikimedia/parsoid/blob/master/tests/mocha/api.js#L69-L435), but I think they're a good start to an API documentation, and a good catalyst for evaluating the evolving design of the V2 API.

You can plug these into http://editor.swagger.io/ to get a better idea of what they encompass.
