### PR TITLE
"--fetchConfig=false" for "basic parse" example to work

### DIFF
--- a/guides/setup/README.md
+++ b/guides/setup/README.md
@@ -66,7 +66,7 @@ This time, go to the `tests/` directory in the Parsoid repository and do
 something like:
 
 ```
-$ echo "some harmless [[wikitext]]" | node parse
+$ echo "some harmless [[wikitext]]" | node parse --fetchConfig=false
 ```
 
 This will run the echoed text through the wikitext parser and show you the


### PR DESCRIPTION
Needed to add this for the "basic parse tool" example to work. (Related: was surprise when, even without any local API config, followup parses of template-containing wikitext grabbed templates from somewhere on the net.)
