### PR TITLE
Added fallback for general.legaltitlechars

### DIFF
--- a/lib/config/WikiConfig.js
+++ b/lib/config/WikiConfig.js
@@ -49,7 +49,7 @@ function WikiConfig(parsoidConfig, resultConf, prefix) {
 		general: {
 			"case": general["case"],
 			lang: general.lang,
-			legaltitlechars: general.legaltitlechars,
+			legaltitlechars: general.legaltitlechars || ' %!"$&\'()*,\\-.\\/0-9:;=?@A-Z\\\\^_`a-z~\\x80-\\xFF+',
 			// For the gallery extension
 			galleryoptions: Object.assign({
 				imagesPerRow: 0,


### PR DESCRIPTION
Some old MediaWiki instances (WikiHow) don't provide all assumed information back.
Not sure if people would prefer the guard be elsewhere in the code?