### PR TITLE
Adding an option to Parsoid class to use the internal native template engine

### DIFF
--- a/src/Parsoid.php
+++ b/src/Parsoid.php
@@ -182,6 +182,8 @@ class Parsoid {
 		}
 		$envOptions['skipLanguageConversionPass'] =
 			$options['skipLanguageConversionPass'] ?? false;
+		$envOptions['nativeTemplateExpansion'] =
+			$options['nativeTemplateExpansion'] ?? false;
 
 		$env = new Env(
 			$this->siteConfig, $pageConfig, $this->dataAccess, $metadata, $envOptions
@@ -222,6 +224,7 @@ class Parsoid {
 	 *   'dumpFlags'            => (array) associative array with dump options
 	 *   'debugFlags'           => (array) associative array with debug options
 	 *   'logLevels'            => (string[]) Levels to log
+	 *   'nativeTemplateExpansion'     => (bool) Whether Parsoid native template engine should be used
 	 * ]
 	 * @param ?array &$headers
 	 * @param ?ContentMetadataCollector $metadata Pass in a CMC in order to


### PR DESCRIPTION
Hello,

I've added a boolean option to Parsoid::wikitext2html whether or not you want to use the internal template engine from Parsoid.
The name of the new flag in the $options array is 'nativeTemplateExpansion' and it is passed to the Env instance.

I'm currently using Parsoid in my project as a standalone library, outside MediaWiki, therefore, I cannot rely on the legacy template engine. I've tried to follow notation rules.

Hope this helps :heart: 

Florent