### PR TITLE
AddLinkAttributes.php - prevent parsing of non-string values

### DIFF
--- a/src/Wt2Html/DOM/Handlers/AddLinkAttributes.php
+++ b/src/Wt2Html/DOM/Handlers/AddLinkAttributes.php
@@ -42,7 +42,8 @@ class AddLinkAttributes {
 						DOMUtils::addRel( $a, $v );
 					}
 				} else {
-					$a->setAttribute( $key, $val );
+					// prevent parsing of non-string values
+					$a->setAttribute( $key, !is_string($val) ? '' : $val );
 				}
 			}
 		} elseif ( DOMUtils::hasRel( $a, 'mw:WikiLink/Interwiki' ) ) {

--- a/src/Wt2Html/DOM/Handlers/AddLinkAttributes.php
+++ b/src/Wt2Html/DOM/Handlers/AddLinkAttributes.php
@@ -42,7 +42,8 @@ class AddLinkAttributes {
 						DOMUtils::addRel( $a, $v );
 					}
 				} else {
-					$a->setAttribute( $key, $val );
+                    // prevent parsing of non-string values
+					$a->setAttribute( $key, !is_string($val) ? '' : $val );
 				}
 			}
 		} elseif ( DOMUtils::hasRel( $a, 'mw:WikiLink/Interwiki' ) ) {


### PR DESCRIPTION
AddLinkAttributes.php - prevent parsing of non-string values

Other Plugins (eg. Visual Editor) will not work if there is some strange user payload in the article.
This results in:
> Exception caught: DOMElement::setAttribute(): Argument #2 ($value) must be of type string, true given",

Example:
> <a target="1" rel="nofollow" class="external text" href="https:domain.tld</a>